### PR TITLE
Remove adf.ly from allowlist due to malvertising risk

### DIFF
--- a/allowlist.txt
+++ b/allowlist.txt
@@ -27,8 +27,6 @@ guzzoni.apple.com
 
 ## url shorteners
 t.ly
-adf.ly
-www.adf.ly
 bit.ly
 www.bit.ly
 goo.gl


### PR DESCRIPTION
adf.ly's business model injects interstitial ads before redirecting,
which are known to serve malvertising, fake download buttons, and scam pop-ups.