### PR TITLE
Remove defunct goo.gl shortener from allowlist

### DIFF
--- a/allowlist.txt
+++ b/allowlist.txt
@@ -29,7 +29,6 @@ guzzoni.apple.com
 t.ly
 bit.ly
 www.bit.ly
-goo.gl
 ow.ly
 www.ow.ly
 amzn.to


### PR DESCRIPTION
goo.gl redirect service was shut down by Google in August 2025.